### PR TITLE
Math ln2 and unary expr

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,9 @@ const visitor = {
       parentPath &&
         t.isBinaryExpression(parentPath.node) &&
         visitor.BinaryExpression.call(this, parentPath);
+      parentPath &&
+        t.isUnaryExpression(parentPath.node) &&
+        visitor.UnaryExpression.call(this, parentPath)
     }
   },
   CallExpression(path) {
@@ -138,6 +141,39 @@ const visitor = {
 
       if (result !== undefined) {
         path.replaceWith(t.numericLiteral(result));
+      }
+    }
+  },
+  UnaryExpression(path) {
+    const node = path.node;
+    if (t.isUnaryExpression(node) && t.isNumericLiteral(node.argument)) {
+      let result
+      switch (node.operator) {
+        case "+":
+          result = +node.argument.value;
+          break;
+        case "-":
+          result = -node.argument.value;
+          break;
+        case "~":
+          result = ~node.argument.value;
+          break;
+        default:
+      }
+
+      if (result !== undefined) {
+        path.replaceWith(t.numericLiteral(result));
+        let parentPath = path.parentPath;
+        if (parentPath) {
+          if (t.isBinaryExpression(parentPath.node)) {
+            // example: 5 + (~3);
+            visitor.BinaryExpression.call(this, parentPath);
+          }
+          if (t.isUnaryExpression(parentPath.node)) {
+            // example: -(~2);
+            visitor.UnaryExpression.call(this, parentPath);
+          }
+        }
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ const visitor = {
 
         switch (method) {
           case "E":
+          case "LN2":
           case "LN10":
           case "LOG2E":
           case "LOG10E":

--- a/test/bit.test.js
+++ b/test/bit.test.js
@@ -44,3 +44,10 @@ test(">>>", t => {
   });
   t.deepEqual(code, `const result = 1;`);
 });
+
+test("~", t => {
+  const { code } = transform(`const result = ~1;`, {
+    plugins: [preCalculateNumberPlugin]
+  });
+  t.deepEqual(code, `const result = -2;`);
+});

--- a/test/complex.test.js
+++ b/test/complex.test.js
@@ -59,3 +59,23 @@ test("complex-4", t => {
 }, 2000);`
   );
 });
+
+test("complex-5", t => {
+  const { code } = transform(
+    `const result = +5 + ~(-3);`,
+    {
+      plugins: [preCalculateNumberPlugin]
+    }
+  );
+  t.deepEqual(code,`const result = 7;`);
+});
+
+test("complex-6", t => {
+  const { code } = transform(
+    `const result = ~(5 ^ 3) * 6;`,
+    {
+      plugins: [preCalculateNumberPlugin]
+    }
+  );
+  t.deepEqual(code,`const result = -42;`);
+});


### PR DESCRIPTION
1. support Math constant `Math.LN2`
2. support unary expressions

**Before**:
![](https://i.loli.net/2018/05/09/5af247a1865f1.png)

**After**:
![](https://i.loli.net/2018/05/09/5af247a1887ed.png)

**P.S.**:  Since there is no `.eslintrc` provided, I am sorry if my code style is not consistent with yours